### PR TITLE
enforce vault input index of 0

### DIFF
--- a/src/vault/contract.rs
+++ b/src/vault/contract.rs
@@ -203,6 +203,7 @@ impl VaultCovenant {
         let tx_commitment_spec = TxCommitmentSpec {
             prev_sciptpubkeys: false,
             prev_amounts: false,
+            input_index: false,
             outputs: false,
             ..Default::default()
         };
@@ -462,6 +463,7 @@ impl VaultCovenant {
         let tx_commitment_spec = TxCommitmentSpec {
             prev_sciptpubkeys: false,
             prev_amounts: false,
+            input_index: false,
             outputs: false,
             ..Default::default()
         };

--- a/src/vault/script.rs
+++ b/src/vault/script.rs
@@ -26,6 +26,8 @@ pub(crate) fn vault_trigger_withdrawal() -> ScriptBuf {
         // start with encoded leaf hash
         .push_opcode(OP_CAT) // encoded leaf hash
         .push_opcode(OP_CAT) // encoded leaf hash
+        .push_slice([0x00u8, 0x00u8, 0x00u8, 0x00u8]) // add input index of 0
+        .push_opcode(OP_SWAP) // bring working sigmsg back to top of stack
         .push_opcode(OP_CAT) // input index
         .push_opcode(OP_CAT) // spend type
         .push_slice(*DUST_AMOUNT) // push the dust amount for the target output
@@ -155,6 +157,8 @@ pub(crate) fn vault_cancel_withdrawal() -> ScriptBuf {
         // start with encoded leaf hash
         .push_opcode(OP_CAT) // encoded leaf hash
         .push_opcode(OP_CAT) // encoded leaf hash
+        .push_slice([0x00u8, 0x00u8, 0x00u8, 0x00u8]) // add input index of 0
+        .push_opcode(OP_SWAP) // bring working sigmsg back to top of stack
         .push_opcode(OP_CAT) // input index
         .push_opcode(OP_CAT) // spend type
         .push_opcode(OP_FROMALTSTACK) // get the output amount

--- a/src/vault/signature_building.rs
+++ b/src/vault/signature_building.rs
@@ -44,6 +44,7 @@ pub(crate) struct TxCommitmentSpec {
     pub(crate) prev_amounts: bool,
     pub(crate) prev_sciptpubkeys: bool,
     pub(crate) sequences: bool,
+    pub(crate) input_index: bool,
     pub(crate) outputs: bool,
     pub(crate) spend_type: bool,
     pub(crate) annex: bool,
@@ -62,6 +63,7 @@ impl Default for TxCommitmentSpec {
             prev_amounts: true,
             prev_sciptpubkeys: true,
             sequences: true,
+            input_index: true,
             outputs: true,
             spend_type: true,
             annex: true,
@@ -262,10 +264,12 @@ pub(crate) fn get_sigmsg_components<S: Into<TapLeafHash>>(
         debug!("input sequence: {:?}", sequence.to_hex_string(Case::Lower));
         components.push(sequence);
     } else {
-        let mut input_idx = Vec::new();
-        (input_index as u32).consensus_encode(&mut input_idx)?;
-        debug!("input index: {:?}", input_idx.to_hex_string(Case::Lower));
-        components.push(input_idx);
+        if spec.input_index {
+            let mut input_idx = Vec::new();
+            (input_index as u32).consensus_encode(&mut input_idx)?;
+            debug!("input index: {:?}", input_idx.to_hex_string(Case::Lower));
+            components.push(input_idx);
+        }
     }
 
     // If an annex is present (the lowest bit of spend_type is set):


### PR DESCRIPTION
update trigger and cancel scripts to force vault input to be first. otherwise if the fee paying transaction is the first input the vault can be drained to fees. (resolves #2 )

if you would like to test this fix you can use my [`fee-drain` branch](https://github.com/monlovesmango/purrfect_vault/tree/fee-drain) which creates a new action for draining via a trigger transaction and draining via a cancel transaction. (there is also a drain via complete transaction but it doesn't work and I don't think it can work).